### PR TITLE
fix: #13 - Allow relative require

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -4,7 +4,6 @@
      * (c) 2017, Egor Churaev egor.churaev@gmail.com
 
 --]]
-
 return {
-    kbdcfg = require("keyboard_layout.kbdcfg")
+    kbdcfg = require(... .. ".kbdcfg")
 }


### PR DESCRIPTION
This will allow the user to put this lib in a folder for better organization for when you have many libs in your configuration.

If the user likes it or prefers to put it in the root, the normal call `local kblayout = require("keyboard_layout")` will also work.